### PR TITLE
Polishing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,69 +1,103 @@
-# Cargo Tools Extension
 
-This VS Code extension provides Rust development tools with build profiles, targets, and workspace integration, similar to the cmake-tools extension.
+# Copilot Coding Agent Onboarding Instructions for cargo-tools
 
-## Architecture
+## Repository Overview
 
-### Core Classes
+- **Purpose:** This repository is a Visual Studio Code extension for Rust development, providing advanced workspace, build, run, test, and benchmark management for Cargo-based Rust projects. It is similar in spirit to the cmake-tools extension but targets Rust and Cargo workflows.
+- **Type:** VS Code extension (TypeScript)
+- **Languages:** TypeScript (main), JavaScript (tests), JSON (configuration)
+- **Size:** Medium (core logic in `src/`, test suite, sample Rust project)
+- **Target Runtime:** Node.js (VS Code extension host)
 
-- **CargoWorkspace**: Main class that manages the Rust workspace, parses Cargo.toml, discovers targets, and executes cargo commands
-- **CargoTarget**: Represents a build target (binary, library, test, etc.)
-- **CargoProfile**: Enum for build profiles (dev, release)
+## Build, Test, and Validation Instructions
 
-### UI Components
+### Environment Setup
+- **Node.js:** Use Node.js v18+ (recommended)
+- **VS Code:** Latest stable version recommended
+- **Rust:** Not required for extension build/test, but useful for validating Rust project integration
+- **Always run `npm install` before building or testing.**
 
-- **ProfilesTreeProvider**: Tree view showing available build profiles
-- **TargetsTreeProvider**: Tree view showing available build targets  
-- **WorkspaceTreeProvider**: Tree view showing workspace structure and files
-- **StatusBarProvider**: Status bar items showing current profile and target
-- **CargoTaskProvider**: Provides VS Code tasks for cargo commands
+### Build Steps
+- **Compile the extension:**
+  ```sh
+  npm run compile
+  ```
+  - Uses Webpack to bundle TypeScript sources from `src/` into `extension.js`.
+  - Output is placed in the default VS Code extension output location.
+  - If you see errors, ensure all dependencies are installed and TypeScript is available.
 
-### Key Features
+### Test Steps
+- **Run the full test suite:**
+  ```sh
+  npm test
+  ```
+  - Runs compile, lint, and all integration/unit tests using `vscode-test`.
+  - Tests are located in `src/test/` and cover command registration, argument generation, and integration logic.
+  - If tests fail, check for missing dependencies or TypeScript errors.
 
-1. **Build Profile Selection**: Switch between dev and release profiles
-2. **Target Selection**: Select which binary/library to build/run
-3. **Integrated Commands**: Build, run, test, debug, clean commands
-4. **Tree Views**: Organized panels for profiles, targets, and workspace
-5. **Status Bar**: Quick access to current configuration
-6. **Task Integration**: VS Code tasks for all cargo operations
-7. **Configuration**: Extensive settings for customization
+### Linting
+- **Lint the codebase:**
+  ```sh
+  npm run lint
+  ```
+  - Uses ESLint with config in `eslint.config.mjs`.
+  - Run after making changes to ensure code style and correctness.
 
-### Extension Integration
+### Clean Build
+- **To ensure a clean build:**
+  ```sh
+  rm -rf out/ dist/ && npm run compile
+  ```
+  - Removes previous build artifacts and recompiles.
 
-The extension integrates with rust-analyzer by:
-- Setting environment variables for current configuration
-- Providing consistent build settings across tools
-- Exposing current target/profile state
+### Common Issues & Workarounds
+- If you see TypeScript or Webpack errors, always run `npm install` first.
+- If VS Code does not recognize the extension, reload the window or restart VS Code.
+- If tests hang or fail due to environment, ensure you are not running in a restricted container and that you have write access to the workspace.
+- If you see errors about missing VS Code APIs, update VS Code and dependencies.
 
-### Development Guidelines
+## Project Layout & Architecture
 
-- Follow VS Code extension best practices
-- Use TypeScript for type safety
-- Implement proper error handling
-- Provide clear user feedback
-- Support workspace-level configuration
-- Maintain backward compatibility
+- **Root Files:**
+  - `package.json`: Extension manifest, scripts, command registration
+  - `tsconfig.json`: TypeScript configuration
+  - `webpack.config.js`: Webpack bundling config
+  - `eslint.config.mjs`: ESLint config
+  - `README.md`: Project overview and usage
+  - `.github/copilot-instructions.md`: (this file)
+- **Source Directory (`src/`):**
+  - `extension.ts`: Main extension entry point
+  - `cargoExtensionManager.ts`: Core singleton managing workspace, commands, and UI
+  - `cargoWorkspace.ts`: Workspace and target discovery logic
+  - `cargoTaskProvider.ts`: VS Code TaskProvider for cargo commands
+  - `cargoProfile.ts`, `cargoTarget.ts`: Types and logic for profiles/targets
+  - `projectOutlineTreeProvider.ts`, `statusBarProvider.ts`, `profilesTreeProvider.ts`, `targetsTreeProvider.ts`, `workspaceTreeProvider.ts`: UI components for tree/status bar views
+  - `test/extension.test.ts`, `test/cargoExtensionManager.test.ts`: Test suites
+- **Sample Rust Project:**
+  - `test-rust-project/`: Used for integration testing
 
-### Commands
+## Validation & CI
+- **Tests:** Always run `npm test` before committing changes. All 51+ tests must pass.
+- **Lint:** Run `npm run lint` before check-in.
+- **Build:** Run `npm run compile` to ensure the extension builds.
+- **No explicit GitHub Actions or CI pipeline is present, but local validation is required.**
 
-- `cargo-tools.build`: Build current target with current profile
-- `cargo-tools.run`: Run current executable target
-- `cargo-tools.test`: Run tests
-- `cargo-tools.debug`: Debug current executable target
-- `cargo-tools.clean`: Clean build artifacts
-- `cargo-tools.selectProfile`: Select build profile
-- `cargo-tools.selectTarget`: Select build target
-- `cargo-tools.refresh`: Refresh workspace information
+## Key Facts for Efficient Agent Work
+- **Command Registration:** All extension commands are registered in `cargoExtensionManager.ts` and listed in `package.json`.
+- **UI Actions:** Tree view and status bar actions are managed in `src/projectOutlineTreeProvider.ts` and `src/statusBarProvider.ts`.
+- **Task Execution:** All cargo command execution is routed through `cargoTaskProvider.ts`.
+- **Tests:** All validation logic is in `src/test/` and covers command registration, argument generation, and integration.
+- **Configuration:** All extension settings are under the `cargoTools` namespace in `package.json`.
+- **Features:** Inline and context menu action buttons for build/run/test/bench are available in the project outline pane and status bar.
 
-### Configuration
+## Agent Guidance
+- **Trust these instructions for build, test, and validation.** Only search the codebase if information here is incomplete or found to be in error.
+- **Always run `npm install` before any build or test.**
+- **Validate changes by running `npm run compile`, `npm run lint`, and `npm test` in that order.**
+- **For UI or command changes, update both `package.json` and the relevant TypeScript files in `src/`.**
+- **For new features, add tests in `src/test/` and validate with `npm test`.**
+- **If you encounter errors, check for missing dependencies, outdated VS Code, or TypeScript issues.**
 
-All settings are under the `cargoTools` namespace:
-- `defaultProfile`: Default build profile
-- `cargoPath`: Path to cargo executable
-- `buildArgs`: Additional build arguments
-- `runArgs`: Additional run arguments
-- `testArgs`: Additional test arguments
-- `environment`: Environment variables
-- `features`: Default features to enable
-- `allFeatures`: Enable all features
-- `noDefaultFeatures`: Disable default features
+---
+
+This onboarding file is intended to minimize exploration and maximize the efficiency and reliability of Copilot coding agent work. If you find any information here to be incomplete or incorrect, perform a targeted search and update this file as needed.

--- a/src/cargoExtensionManager.ts
+++ b/src/cargoExtensionManager.ts
@@ -1330,16 +1330,9 @@ export class CargoExtensionManager implements vscode.Disposable {
             return;
         }
 
-        const currentFeatures = new Set(this.cargoWorkspace.selectedFeatures);
-
-        if (currentFeatures.has(feature)) {
-            currentFeatures.delete(feature);
-        } else {
-            currentFeatures.add(feature);
-        }
-
-        this.cargoWorkspace.setSelectedFeatures(currentFeatures);
-        console.log(`Toggled feature: ${feature} ${currentFeatures.has(feature) ? 'ON' : 'OFF'}`);
+        // Use the workspace's toggleFeature method which has proper mutual exclusion logic
+        this.cargoWorkspace.toggleFeature(feature);
+        console.log(`Toggled feature: ${feature}`);
     }
 
     // ==================== PROJECT OUTLINE ACTION COMMANDS ====================

--- a/src/cargoExtensionManager.ts
+++ b/src/cargoExtensionManager.ts
@@ -776,13 +776,16 @@ export class CargoExtensionManager implements vscode.Disposable {
         const items: vscode.QuickPickItem[] = [];
         const selectedPackage = this.cargoWorkspace.selectedPackage;
 
+        // Always add "No selection" option first
+        items.push({
+            label: 'No selection',
+            description: 'Run all benchmarks (no target specification)',
+            detail: 'No benchmark target selection'
+        });
+
         if (!selectedPackage) {
-            // "All" Package Selected - only show "All" option
-            items.push({
-                label: 'All',
-                description: 'Run all benchmarks (no target specification)',
-                detail: 'All benchmarks'
-            });
+            vscode.window.showWarningMessage('Select a specific package to run benchmark targets');
+            return;
         } else {
             // Specific Package Selected - show benchmarks from selected package
             const packageTargets = this.getTargetsForPackage(selectedPackage);
@@ -809,8 +812,9 @@ export class CargoExtensionManager implements vscode.Disposable {
         });
 
         if (selected) {
-            // Store benchmark target selection
-            this.cargoWorkspace.setSelectedBenchmarkTarget(selected.label);
+            // Store benchmark target selection - handle "No selection" case
+            const targetToSet = selected.label === 'No selection' ? null : selected.label;
+            this.cargoWorkspace.setSelectedBenchmarkTarget(targetToSet);
         }
     }
 

--- a/src/cargoTaskProvider.ts
+++ b/src/cargoTaskProvider.ts
@@ -432,12 +432,17 @@ export class CargoTaskProvider implements vscode.TaskProvider {
         const hasAllFeatures = selectedFeatures.includes('all-features');
         const regularFeatures = selectedFeatures.filter(f => f !== 'all-features');
 
+        // Only include package name if workspace has a specific package selected
+        // When no package is selected (undefined), we want to build all packages
+        const selectedPackage = this.workspace?.selectedPackage;
+        const packageName = selectedPackage ? target.packageName : undefined;
+
         const definition: CargoTaskDefinition = {
             type: 'cargo',
             command: command,
             targetName: target.name,
             targetKind: validKind,
-            packageName: target.packageName,
+            packageName: packageName,
             features: regularFeatures.length > 0 ? regularFeatures : undefined,
             allFeatures: hasAllFeatures
         };

--- a/src/cargoWorkspace.ts
+++ b/src/cargoWorkspace.ts
@@ -55,10 +55,10 @@ export class CargoWorkspace {
     private _targets: CargoTarget[] = [];
     private _currentProfile: CargoProfile = CargoProfile.dev;
     private _currentTarget: CargoTarget | null = null;
-    private _selectedPackage: string | undefined = undefined; // undefined means "All"
+    private _selectedPackage: string | undefined = undefined; // undefined means "No selection"
     private _workspacePackageNames: string[] = []; // Package names from cargo metadata
     private _packageFeatures: Map<string, string[]> = new Map(); // Features available for each package
-    private _selectedBuildTarget: string | null = null; // Selected build target
+    private _selectedBuildTarget: string | null = null; // null means "No selection"
     private _selectedRunTarget: string | null = null; // Selected run target
     private _selectedBenchmarkTarget: string | null = null; // Selected benchmark target
     private _selectedFeatures: Set<string> = new Set(); // Selected features, default to none (no features selected)
@@ -480,12 +480,12 @@ export class CargoWorkspace {
     getAvailableFeatures(): string[] {
         const features = ['all-features']; // Always include all-features option
 
-        if (this._selectedPackage && this._selectedPackage !== 'All') {
+        if (this._selectedPackage) {
             // When a specific package is selected, show its features
             const packageFeatures = this.getPackageFeatures(this._selectedPackage);
             features.push(...packageFeatures);
         }
-        // When "All" is selected, only show "all-features"
+        // When no selection, only show "all-features"
 
         return features;
     }
@@ -547,6 +547,11 @@ export class CargoWorkspace {
         // Add profile
         if (this._currentProfile === CargoProfile.release) {
             args.push('--release');
+        }
+
+        // Add package argument if a specific package is selected and we're in a workspace
+        if (this._selectedPackage && this.isWorkspace) {
+            args.push('--package', this._selectedPackage);
         }
 
         // Add target

--- a/src/projectOutlineTreeProvider.ts
+++ b/src/projectOutlineTreeProvider.ts
@@ -291,7 +291,7 @@ export class ProjectOutlineTreeProvider implements vscode.TreeDataProvider<Proje
 
                 if (selectedBuildTarget === 'lib' && target.kind.includes('lib')) {
                     // Only show icon if this library target belongs to the selected package
-                    // If no package is selected ("All"), don't show library indicators
+                    // If no package is selected, don't show library indicators
                     isBuildTarget = selectedPackage !== undefined && target.packageName === selectedPackage;
                 } else {
                     isBuildTarget = selectedBuildTarget === target.name;

--- a/src/projectOutlineTreeProvider.ts
+++ b/src/projectOutlineTreeProvider.ts
@@ -162,7 +162,7 @@ export class ProjectOutlineTreeProvider implements vscode.TreeDataProvider<Proje
             'Features available for the entire project',
             { packageName: undefined, features: ['all-features'] }
         );
-        rootFeaturesNode.iconPath = new vscode.ThemeIcon('settings-gear');
+        rootFeaturesNode.iconPath = new vscode.ThemeIcon('symbol-misc');
         nodes.push(rootFeaturesNode);
 
         if (this.groupByWorkspaceMember && this.workspace.isWorkspace) {
@@ -244,6 +244,7 @@ export class ProjectOutlineTreeProvider implements vscode.TreeDataProvider<Proje
                     { packageName: data.memberName, features: packageFeatures }
                 );
                 featuresNode.iconPath = new vscode.ThemeIcon('settings-gear');
+                featuresNode.iconPath = new vscode.ThemeIcon('symbol-misc');
                 nodes.push(featuresNode);
             }
         }

--- a/src/projectStatusTreeProvider.ts
+++ b/src/projectStatusTreeProvider.ts
@@ -408,58 +408,20 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
             node.iconPath = new vscode.ThemeIcon('check');
             return [node];
         } else {
-            // Show default "No selection" or disabled state
-            const selectedPackage = this.workspace.selectedPackage;
-            if (!selectedPackage) {
-                // No package selected - show "No selection" option
-                const node = new ProjectStatusNode(
-                    'No selection',
-                    vscode.TreeItemCollapsibleState.None,
-                    'default-benchmark-target',
-                    {
-                        command: 'cargo-tools.selectBenchmarkTarget',
-                        title: 'Select Benchmark Target'
-                    },
-                    'Run all benchmarks (default)',
-                    'Click to select specific benchmark target'
-                );
-                node.iconPath = new vscode.ThemeIcon('dashboard');
-                return [node];
-            } else {
-                // Specific package selected - check if benchmark targets exist
-                const packageTargets = this.getTargetsForPackage(selectedPackage);
-                const targetsByType = this.groupTargetsByType(packageTargets);
-                const hasBenchmarkTargets = targetsByType.has('bench');
-
-                if (hasBenchmarkTargets) {
-                    // Show default "All benchmarks in package" option
-                    const node = new ProjectStatusNode(
-                        'All benchmarks',
-                        vscode.TreeItemCollapsibleState.None,
-                        'default-benchmark-target',
-                        {
-                            command: 'cargo-tools.selectBenchmarkTarget',
-                            title: 'Select Benchmark Target'
-                        },
-                        `Run all benchmarks in ${selectedPackage} (default)`,
-                        'Click to select specific benchmark target'
-                    );
-                    node.iconPath = new vscode.ThemeIcon('dashboard');
-                    return [node];
-                } else {
-                    // No benchmark targets in package
-                    const node = new ProjectStatusNode(
-                        'No benchmarks in package',
-                        vscode.TreeItemCollapsibleState.None,
-                        'no-benchmark-targets',
-                        undefined,
-                        'No benchmark targets',
-                        'This package has no benchmark targets'
-                    );
-                    node.iconPath = new vscode.ThemeIcon('circle-slash');
-                    return [node];
-                }
-            }
+            // Show "No selection" when no specific benchmark target is selected
+            const node = new ProjectStatusNode(
+                'No selection',
+                vscode.TreeItemCollapsibleState.None,
+                'default-benchmark-target',
+                {
+                    command: 'cargo-tools.selectBenchmarkTarget',
+                    title: 'Select Benchmark Target'
+                },
+                'No benchmark target selected',
+                'Click to select benchmark target'
+            );
+            node.iconPath = new vscode.ThemeIcon('dashboard');
+            return [node];
         }
     }
 

--- a/src/projectStatusTreeProvider.ts
+++ b/src/projectStatusTreeProvider.ts
@@ -191,7 +191,7 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
         if (this.workspace.isWorkspace) {
             // Multi-package workspace - show current selection with dropdown
             const selectedPackage = this.workspace.selectedPackage;
-            const displayName = selectedPackage || 'All packages';
+            const displayName = selectedPackage || 'No selection';
 
             const packageNode = new ProjectStatusNode(
                 displayName,
@@ -293,39 +293,20 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
             node.iconPath = new vscode.ThemeIcon('check');
             return [node];
         } else {
-            // Show default "All" or disabled state
-            const selectedPackage = this.workspace.selectedPackage;
-            if (!selectedPackage) {
-                // "All" packages selected - show "All targets" option
-                const node = new ProjectStatusNode(
-                    'All targets',
-                    vscode.TreeItemCollapsibleState.None,
-                    'default-build-target',
-                    {
-                        command: 'cargo-tools.selectBuildTarget',
-                        title: 'Select Build Target'
-                    },
-                    'Build all targets (default)',
-                    'Click to select specific build target'
-                );
-                node.iconPath = new vscode.ThemeIcon('target');
-                return [node];
-            } else {
-                // Specific package selected - show "All targets in package" option
-                const node = new ProjectStatusNode(
-                    'All targets',
-                    vscode.TreeItemCollapsibleState.None,
-                    'default-build-target',
-                    {
-                        command: 'cargo-tools.selectBuildTarget',
-                        title: 'Select Build Target'
-                    },
-                    `Build all targets in ${selectedPackage} (default)`,
-                    'Click to select specific build target'
-                );
-                node.iconPath = new vscode.ThemeIcon('target');
-                return [node];
-            }
+            // No build target selected - always show "No selection"
+            const node = new ProjectStatusNode(
+                'No selection',
+                vscode.TreeItemCollapsibleState.None,
+                'default-build-target',
+                {
+                    command: 'cargo-tools.selectBuildTarget',
+                    title: 'Select Build Target'
+                },
+                'No build target selected (build all targets)',
+                'Click to select specific build target'
+            );
+            node.iconPath = new vscode.ThemeIcon('target');
+            return [node];
         }
     }
 
@@ -355,9 +336,9 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
             // Show disabled or default state
             const selectedPackage = this.workspace.selectedPackage;
             if (!selectedPackage) {
-                // "All" packages selected - disabled
+                // No package selected - disabled
                 const node = new ProjectStatusNode(
-                    'Disabled when "All" packages selected',
+                    'Disabled when no package selected',
                     vscode.TreeItemCollapsibleState.None,
                     'disabled-run-target',
                     undefined,
@@ -427,12 +408,12 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
             node.iconPath = new vscode.ThemeIcon('check');
             return [node];
         } else {
-            // Show default "All" or disabled state
+            // Show default "No selection" or disabled state
             const selectedPackage = this.workspace.selectedPackage;
             if (!selectedPackage) {
-                // "All" packages selected - show "All benchmarks" option
+                // No package selected - show "No selection" option
                 const node = new ProjectStatusNode(
-                    'All benchmarks',
+                    'No selection',
                     vscode.TreeItemCollapsibleState.None,
                     'default-benchmark-target',
                     {

--- a/src/statusBarProvider.ts
+++ b/src/statusBarProvider.ts
@@ -362,7 +362,7 @@ class BenchmarkTargetSelectionButton extends StatusBarButton {
         super(config, priority);
         this.hidden = false;
         this.command = 'cargo-tools.selectBenchmarkTarget';
-        this.icon = 'zap';
+        this.icon = 'dashboard';
         this.tooltip = 'Click to change the active benchmark target';
     }
 

--- a/src/statusBarProvider.ts
+++ b/src/statusBarProvider.ts
@@ -351,7 +351,7 @@ class RunTargetSelectionButton extends StatusBarButton {
  * Benchmark Target Selection Button
  */
 class BenchmarkTargetSelectionButton extends StatusBarButton {
-    private static readonly _noBenchmarkTargetSelected = 'No Benchmark Target Selected';
+    private static readonly _noBenchmarkTargetSelected = 'No selection';
 
     settingsName = 'benchmarkTarget';
     constructor(protected readonly config: CargoConfigurationReader, protected readonly priority: number) {

--- a/src/statusBarProvider.ts
+++ b/src/statusBarProvider.ts
@@ -60,7 +60,7 @@ abstract class StatusBarButton {
     }
 
     protected set icon(v: string | null) {
-        this._icon = v ? `$(${v})` : null;
+        this._icon = v ? `$(${v === 'settings-gear' ? 'symbol-misc' : v})` : null;
     }
 
     protected set command(v: string | null) {
@@ -402,7 +402,7 @@ class FeatureSelectionButton extends StatusBarButton {
         super(config, priority);
         this.hidden = false;
         this.command = 'cargo-tools.selectFeatures';
-        this.icon = 'list-unordered';
+        this.icon = 'symbol-misc';
         this.tooltip = 'Click to change the active features';
     }
 

--- a/src/statusBarProvider.ts
+++ b/src/statusBarProvider.ts
@@ -227,8 +227,7 @@ class ProfileSelectionButton extends StatusBarButton {
  * Package Selection Button
  */
 class PackageSelectionButton extends StatusBarButton {
-    private static readonly _allPackagesSelected = 'All';
-    private static readonly _noPackageSelected = 'No Package Selected';
+    private static readonly _noPackageSelected = 'No Selection';
 
     settingsName = 'package';
     constructor(protected readonly config: CargoConfigurationReader, protected readonly priority: number) {
@@ -241,11 +240,8 @@ class PackageSelectionButton extends StatusBarButton {
 
     protected getTextNormal(): string {
         const text = this.text;
-        if (text.length === 0) {
+        if (text.length === 0 || text === undefined) {
             return PackageSelectionButton._noPackageSelected;
-        }
-        if (text === 'All' || text === undefined) {
-            return PackageSelectionButton._allPackagesSelected;
         }
         return this.bracketText;
     }
@@ -270,7 +266,7 @@ class PackageSelectionButton extends StatusBarButton {
  * Build Target Selection Button
  */
 class BuildTargetSelectionButton extends StatusBarButton {
-    private static readonly _noBuildTargetSelected = 'No Build Target Selected';
+    private static readonly _noBuildTargetSelected = 'No Selection';
 
     settingsName = 'buildTarget';
     constructor(protected readonly config: CargoConfigurationReader, protected readonly priority: number) {
@@ -345,7 +341,7 @@ class RunTargetSelectionButton extends StatusBarButton {
 
     protected isVisible(): boolean {
         // Only show benchmark target when a specific package is selected  
-        // Hide when "All" is selected or no package is selected
+        // Hide when no package is selected
         // This is controlled by updateTargetButtonsVisibility method
         return super.isVisible();
     }
@@ -582,7 +578,7 @@ export class StatusBarProvider implements vscode.Disposable {
 
     // Package methods
     setPackageName(packageName: string | undefined): void {
-        this._packageButton.text = packageName || 'All';
+        this._packageButton.text = packageName || '';
     }
 
     // Target methods

--- a/test-rust-project/utils/Cargo.toml
+++ b/test-rust-project/utils/Cargo.toml
@@ -12,6 +12,11 @@ name = "performance"
 path = "benches/perf.rs"
 harness = false
 
+[[bench]]
+name = "performance_alt"
+path = "benches/perf_alt.rs"
+harness = false
+
 [dependencies]
 core = { path = "../core" }
 serde = { workspace = true }

--- a/test-rust-project/utils/benches/perf_alt.rs
+++ b/test-rust-project/utils/benches/perf_alt.rs
@@ -1,0 +1,39 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use utils::{data::*, strings};
+
+fn benchmark_string_operations(c: &mut Criterion) {
+    let test_string = "This is a test string for benchmarking string operations";
+
+    c.bench_function("capitalize", |b| {
+        b.iter(|| strings::capitalize(black_box(test_string)))
+    });
+
+    c.bench_function("reverse", |b| {
+        b.iter(|| strings::reverse(black_box(test_string)))
+    });
+
+    c.bench_function("word_count", |b| {
+        b.iter(|| strings::word_count(black_box(test_string)))
+    });
+}
+
+fn benchmark_data_operations(c: &mut Criterion) {
+    let data_points: Vec<DataPoint> = (0..1000)
+        .map(|i| DataPoint::new(i, (i as f64) * 1.5, format!("Point_{}", i)))
+        .collect();
+
+    c.bench_function("process_data_points", |b| {
+        b.iter(|| process_data_points(black_box(&data_points)))
+    });
+
+    c.bench_function("filter_by_threshold", |b| {
+        b.iter(|| filter_by_threshold(black_box(&data_points), black_box(500.0)))
+    });
+}
+
+criterion_group!(
+    benches,
+    benchmark_string_operations,
+    benchmark_data_operations
+);
+criterion_main!(benches);


### PR DESCRIPTION
This pull request refines the package and target selection logic throughout the extension to use "No selection" as the default state instead of "All" or "default." It improves clarity and consistency in the UI and command handling, ensuring that actions and argument generation correctly reflect when no package or target is selected. The changes also update related messaging and logic for toggling features and building/running/benchmarking targets.

**UI/UX Consistency Improvements**
* Changed all package and target selection UI to use "No selection" as the default option, replacing previous "All" or "default" labels. This affects quick pick dialogs, status bar updates, and warning messages. [[1]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L601-R608) [[2]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L642-L660) [[3]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L782-R788) [[4]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L616-L629) [[5]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L712-R710) [[6]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L726-R723) [[7]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L815-R817) [[8]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L1214-R1219) [[9]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L1706-R1704)
* Updated log and warning messages to reference "No selection" instead of "All packages" or "default." [[1]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L425-R425) [[2]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L726-R723) [[3]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L1706-R1704)

**Command and Argument Handling**
* Refined logic for determining when to include the `-p` package argument in cargo commands, now only adding it when a specific package is selected in a workspace, and not when "No selection" is active. [[1]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52R1126-R1133) [[2]](diffhunk://#diff-6ff3256a425b4a0a326507a1619743ccc99c0a0fcb25162844aefaee4904e405R435-R445)
* Updated build, run, and benchmark command logic to properly handle the new "No selection" state, ensuring correct argument generation and user feedback. [[1]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L1623-R1621) [[2]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L1642-R1640) [[3]](diffhunk://#diff-9b5043b5c49fe99069b447c12e662e1ace68554c1d0651e348ce22a1e531ca52L1673-R1671)

**Feature Selection Logic**
* Changed feature toggling to use the workspace's dedicated `toggleFeature` method for proper mutual exclusion and state management, improving reliability.

**Documentation**
* Replaced the architecture and feature overview in `.github/copilot-instructions.md` with a comprehensive onboarding guide for Copilot agents, including build, test, validation, and project layout instructions.