### PR TITLE
feat: Add platform target selection with UI integration and cargo command support

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,18 @@
         "icon": "$(dashboard)"
       },
       {
+        "command": "cargo-tools.selectPlatformTarget",
+        "title": "Select Platform Target",
+        "category": "Cargo Tools",
+        "icon": "$(device-desktop)"
+      },
+      {
+        "command": "cargo-tools.installPlatformTarget",
+        "title": "Install Platform Target",
+        "category": "Cargo Tools",
+        "icon": "$(cloud-download)"
+      },
+      {
         "command": "cargo-tools.selectFeatures",
         "title": "Select Features",
         "category": "Cargo Tools",
@@ -201,6 +213,11 @@
       "view/title": [
         {
           "command": "cargo-tools.refresh",
+          "when": "view == cargoToolsProjectStatus",
+          "group": "navigation"
+        },
+        {
+          "command": "cargo-tools.installPlatformTarget",
           "when": "view == cargoToolsProjectStatus",
           "group": "navigation"
         }

--- a/src/cargoTaskProvider.ts
+++ b/src/cargoTaskProvider.ts
@@ -344,6 +344,11 @@ export class CargoTaskProvider implements vscode.TaskProvider {
             args.push('--no-default-features');
         }
 
+        // Add platform target if selected
+        if (this.workspace.selectedPlatformTarget) {
+            args.push('--target', this.workspace.selectedPlatformTarget);
+        }
+
         // Add configuration-based arguments
         const config = vscode.workspace.getConfiguration('cargoTools');
         const commandArgs = config.get<string[]>(`${definition.command}Args`, []);

--- a/src/projectStatusTreeProvider.ts
+++ b/src/projectStatusTreeProvider.ts
@@ -60,6 +60,7 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
                 this.workspace.onDidChangeSelectedBuildTarget(() => this.refresh()),
                 this.workspace.onDidChangeSelectedRunTarget(() => this.refresh()),
                 this.workspace.onDidChangeSelectedBenchmarkTarget(() => this.refresh()),
+                this.workspace.onDidChangeSelectedPlatformTarget(() => this.refresh()),
                 this.workspace.onDidChangeSelectedFeatures(() => this.refresh())
             );
         }
@@ -90,6 +91,15 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
 
     private createRootNodes(): ProjectStatusNode[] {
         const nodes: ProjectStatusNode[] = [];
+
+        // Platform Selection node
+        const platformNode = new ProjectStatusNode(
+            'Platform Selection',
+            vscode.TreeItemCollapsibleState.Expanded,
+            'platformSelection'
+        );
+        platformNode.iconPath = new vscode.ThemeIcon('device-desktop');
+        nodes.push(platformNode);
 
         // Build Configuration node
         const configNode = new ProjectStatusNode(
@@ -136,6 +146,8 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
         }
 
         switch (element.contextValue) {
+            case 'platformSelection':
+                return this.createPlatformSelectionChildren();
             case 'buildConfiguration':
                 return this.createBuildConfigurationChildren();
             case 'packageSelection':
@@ -152,6 +164,46 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
                 return this.createFeatureSelectionChildren();
             default:
                 return [];
+        }
+    }
+
+    private createPlatformSelectionChildren(): ProjectStatusNode[] {
+        if (!this.workspace) {
+            return [];
+        }
+
+        const selectedPlatformTarget = this.workspace.selectedPlatformTarget;
+
+        if (selectedPlatformTarget) {
+            // Show selected platform target with command to change selection
+            const node = new ProjectStatusNode(
+                selectedPlatformTarget,
+                vscode.TreeItemCollapsibleState.None,
+                'selected-platform-target',
+                {
+                    command: 'cargo-tools.selectPlatformTarget',
+                    title: 'Change Platform Target'
+                },
+                `Selected platform target: ${selectedPlatformTarget}`,
+                `Click to change platform target`
+            );
+            node.iconPath = new vscode.ThemeIcon('check');
+            return [node];
+        } else {
+            // Show "No selection" when no specific platform target is selected
+            const node = new ProjectStatusNode(
+                'No selection',
+                vscode.TreeItemCollapsibleState.None,
+                'default-platform-target',
+                {
+                    command: 'cargo-tools.selectPlatformTarget',
+                    title: 'Select Platform Target'
+                },
+                'No platform target selected (use default)',
+                'Click to select platform target'
+            );
+            node.iconPath = new vscode.ThemeIcon('device-desktop');
+            return [node];
         }
     }
 

--- a/src/statusBarProvider.ts
+++ b/src/statusBarProvider.ts
@@ -387,6 +387,45 @@ class BenchmarkTargetSelectionButton extends StatusBarButton {
 }
 
 /**
+ * Platform Target Selection Button
+ */
+class PlatformTargetSelectionButton extends StatusBarButton {
+    private static readonly _noPlatformTargetSelected = 'No selection';
+
+    settingsName = 'platformTarget';
+    constructor(protected readonly config: CargoConfigurationReader, protected readonly priority: number) {
+        super(config, priority);
+        this.hidden = false;
+        this.command = 'cargo-tools.selectPlatformTarget';
+        this.icon = 'device-desktop';
+        this.tooltip = 'Click to change the active platform target';
+    }
+
+    protected getTextNormal(): string {
+        const text = this.text;
+        if (text.length === 0) {
+            return PlatformTargetSelectionButton._noPlatformTargetSelected;
+        }
+        return this.bracketText;
+    }
+
+    protected getTextShort(): string {
+        const text = this.getTextNormal();
+        if (text.length > 20) {
+            return `${text.substr(0, 17)}...]`;
+        }
+        return text;
+    }
+
+    protected getTooltipShort(): string | null {
+        if (this.getTextNormal() === this.getTextShort()) {
+            return this.prependCargo(this.getTooltipNormal());
+        }
+        return super.getTooltipShort();
+    }
+}
+
+/**
  * Feature Selection Button
  */
 class FeatureSelectionButton extends StatusBarButton {
@@ -523,6 +562,7 @@ export class StatusBarProvider implements vscode.Disposable {
     private readonly _testActionButton: TestActionButton;
     private readonly _benchmarkTargetButton: BenchmarkTargetSelectionButton;
     private readonly _benchmarkActionButton: BenchmarkActionButton;
+    private readonly _platformTargetButton: PlatformTargetSelectionButton;
     private readonly _featuresButton: FeatureSelectionButton;
 
     private readonly _buttons: StatusBarButton[];
@@ -530,6 +570,7 @@ export class StatusBarProvider implements vscode.Disposable {
     constructor(private readonly _config: CargoConfigurationReader) {
         // Initialize buttons after config is set
         // Priorities: selection button, then action button next to it (slightly lower priority)
+        this._platformTargetButton = new PlatformTargetSelectionButton(this._config, 4.1);
         this._profileButton = new ProfileSelectionButton(this._config, 4.0);
         this._packageButton = new PackageSelectionButton(this._config, 3.9);
         this._testActionButton = new TestActionButton(this._config, 3.85);
@@ -542,6 +583,7 @@ export class StatusBarProvider implements vscode.Disposable {
         this._featuresButton = new FeatureSelectionButton(this._config, 3.5);
 
         this._buttons = [
+            this._platformTargetButton,
             this._profileButton,
             this._packageButton,
             this._testActionButton,
@@ -592,6 +634,10 @@ export class StatusBarProvider implements vscode.Disposable {
 
     setBenchmarkTargetName(targetName: string | null): void {
         this._benchmarkTargetButton.text = targetName || '';
+    }
+
+    setPlatformTargetName(targetTriple: string | null): void {
+        this._platformTargetButton.text = targetTriple || '';
     }
 
     // Feature methods


### PR DESCRIPTION
- Add platform target selection state and events to CargoWorkspace
- Implement methods for listing, selecting, and installing platform targets via rustup
- Add platform selection to project status pane above configuration
- Include 'No selection' default option with automatic host target fallback
- Add 'Select Platform Target' and 'Install Platform Target' commands to command palette
- Integrate platform target into cargo argument construction (--target flag)
- Update task provider to include platform target in all cargo commands
- Add platform target button to status bar (positioned left of profile selection)
- Ensure platform target persists across package selection changes
- Add UI integration with tree view refresh on platform target changes
- Support both installed target selection and new target installation workflows

Platform targets are now fully integrated into the build system and will be
automatically included in all cargo commands when a specific target is selected.