### PR TITLE
Add custom profile support: discover profiles from Cargo.toml and Config.toml

### DIFF
--- a/src/cargoExtensionManager.ts
+++ b/src/cargoExtensionManager.ts
@@ -115,7 +115,7 @@ export class CargoExtensionManager implements vscode.Disposable {
                 console.log(`Default profile changed to: ${profile}`);
                 // Update active profile if needed
                 if (this.cargoWorkspace) {
-                    this.cargoWorkspace.setProfile(profile as CargoProfile);
+                    this.cargoWorkspace.setProfile(CargoProfile.fromString(profile));
                 }
             }),
 

--- a/src/cargoExtensionManager.ts
+++ b/src/cargoExtensionManager.ts
@@ -585,9 +585,10 @@ export class CargoExtensionManager implements vscode.Disposable {
             return;
         }
 
-        const profiles = [CargoProfile.dev, CargoProfile.release];
+        const profiles = CargoProfile.getAllProfiles();
         const profileItems = profiles.map(profile => ({
             label: CargoProfile.getDisplayName(profile),
+            description: CargoProfile.getDescription(profile),
             profile: profile
         }));
 

--- a/src/cargoProfile.ts
+++ b/src/cargoProfile.ts
@@ -1,6 +1,9 @@
 export enum CargoProfile {
+    none = 'none',
     dev = 'dev',
-    release = 'release'
+    release = 'release',
+    test = 'test',
+    bench = 'bench'
 }
 
 export namespace CargoProfile {
@@ -8,8 +11,16 @@ export namespace CargoProfile {
         switch (str.toLowerCase()) {
             case 'release':
                 return CargoProfile.release;
+            case 'test':
+                return CargoProfile.test;
+            case 'bench':
+                return CargoProfile.bench;
             case 'dev':
             case 'debug':
+                return CargoProfile.dev;
+            case 'none':
+            case '':
+                return CargoProfile.none;
             default:
                 return CargoProfile.dev;
         }
@@ -21,23 +32,39 @@ export namespace CargoProfile {
 
     export function getDisplayName(profile: CargoProfile): string {
         switch (profile) {
+            case CargoProfile.none:
+                return 'No selection';
             case CargoProfile.dev:
                 return 'Development';
             case CargoProfile.release:
                 return 'Release';
+            case CargoProfile.test:
+                return 'Test';
+            case CargoProfile.bench:
+                return 'Bench';
+            default:
+                return 'Development';
         }
     }
 
     export function getDescription(profile: CargoProfile): string {
         switch (profile) {
+            case CargoProfile.none:
+                return 'No profile selection - use default cargo behavior';
             case CargoProfile.dev:
-                return 'Development profile with debug information and fast compilation';
+                return 'Development profile (--profile dev) with debug information and fast compilation';
             case CargoProfile.release:
-                return 'Release profile with optimizations and smaller binary size';
+                return 'Release profile (--profile release) with optimizations and smaller binary size';
+            case CargoProfile.test:
+                return 'Test profile (--profile test) optimized for running tests';
+            case CargoProfile.bench:
+                return 'Bench profile (--profile bench) optimized for running benchmarks';
+            default:
+                return 'Development profile (--profile dev) with debug information and fast compilation';
         }
     }
 
     export function getAllProfiles(): CargoProfile[] {
-        return [CargoProfile.dev, CargoProfile.release];
+        return [CargoProfile.none, CargoProfile.dev, CargoProfile.release, CargoProfile.test, CargoProfile.bench];
     }
 }

--- a/src/cargoProfile.ts
+++ b/src/cargoProfile.ts
@@ -1,20 +1,31 @@
-export enum CargoProfile {
-    none = 'none',
-    dev = 'dev',
-    release = 'release',
-    test = 'test',
-    bench = 'bench'
-}
+export class CargoProfile {
+    private static readonly STANDARD_PROFILES = ['none', 'dev', 'release', 'test', 'bench', 'doc'];
+    private static customProfiles: Set<string> = new Set();
 
-export namespace CargoProfile {
-    export function fromString(str: string): CargoProfile {
-        switch (str.toLowerCase()) {
+    static readonly none = new CargoProfile('none');
+    static readonly dev = new CargoProfile('dev');
+    static readonly release = new CargoProfile('release');
+    static readonly test = new CargoProfile('test');
+    static readonly bench = new CargoProfile('bench');
+    static readonly doc = new CargoProfile('doc');
+
+    constructor(private readonly value: string) { }
+
+    toString(): string {
+        return this.value;
+    }
+
+    static fromString(str: string): CargoProfile {
+        const normalized = str.toLowerCase();
+        switch (normalized) {
             case 'release':
                 return CargoProfile.release;
             case 'test':
                 return CargoProfile.test;
             case 'bench':
                 return CargoProfile.bench;
+            case 'doc':
+                return CargoProfile.doc;
             case 'dev':
             case 'debug':
                 return CargoProfile.dev;
@@ -22,49 +33,93 @@ export namespace CargoProfile {
             case '':
                 return CargoProfile.none;
             default:
-                return CargoProfile.dev;
+                // For custom profiles, create a new instance
+                return new CargoProfile(str);
         }
     }
 
+    static addCustomProfile(profileName: string): void {
+        if (!this.STANDARD_PROFILES.includes(profileName.toLowerCase())) {
+            this.customProfiles.add(profileName);
+        }
+    }
+
+    static getCustomProfiles(): string[] {
+        return Array.from(this.customProfiles).sort();
+    }
+
+    static clearCustomProfiles(): void {
+        this.customProfiles.clear();
+    }
+
+    isCustom(): boolean {
+        return !CargoProfile.STANDARD_PROFILES.includes(this.value.toLowerCase());
+    }
+
+    equals(other: CargoProfile): boolean {
+        return this.value === other.value;
+    }
+}
+
+export namespace CargoProfile {
     export function toString(profile: CargoProfile): string {
         return profile.toString();
     }
 
     export function getDisplayName(profile: CargoProfile): string {
-        switch (profile) {
-            case CargoProfile.none:
+        const value = profile.toString();
+        switch (value) {
+            case 'none':
                 return 'No selection';
-            case CargoProfile.dev:
+            case 'dev':
                 return 'Development';
-            case CargoProfile.release:
+            case 'release':
                 return 'Release';
-            case CargoProfile.test:
+            case 'test':
                 return 'Test';
-            case CargoProfile.bench:
+            case 'bench':
                 return 'Bench';
+            case 'doc':
+                return 'Doc';
             default:
-                return 'Development';
+                // For custom profiles, capitalize first letter
+                return value.charAt(0).toUpperCase() + value.slice(1);
         }
     }
 
     export function getDescription(profile: CargoProfile): string {
-        switch (profile) {
-            case CargoProfile.none:
+        const value = profile.toString();
+        switch (value) {
+            case 'none':
                 return 'No profile selection - use default cargo behavior';
-            case CargoProfile.dev:
+            case 'dev':
                 return 'Development profile (--profile dev) with debug information and fast compilation';
-            case CargoProfile.release:
+            case 'release':
                 return 'Release profile (--profile release) with optimizations and smaller binary size';
-            case CargoProfile.test:
+            case 'test':
                 return 'Test profile (--profile test) optimized for running tests';
-            case CargoProfile.bench:
+            case 'bench':
                 return 'Bench profile (--profile bench) optimized for running benchmarks';
+            case 'doc':
+                return 'Doc profile (--profile doc) optimized for documentation generation';
             default:
-                return 'Development profile (--profile dev) with debug information and fast compilation';
+                return `Custom profile (--profile ${value}) with user-defined settings`;
         }
     }
 
     export function getAllProfiles(): CargoProfile[] {
-        return [CargoProfile.none, CargoProfile.dev, CargoProfile.release, CargoProfile.test, CargoProfile.bench];
+        const standardProfiles = [
+            CargoProfile.none,
+            CargoProfile.dev,
+            CargoProfile.release,
+            CargoProfile.test,
+            CargoProfile.bench
+            // Note: CargoProfile.doc is excluded from selection as it's not typically user-selectable
+        ];
+
+        const customProfileNames = CargoProfile.getCustomProfiles();
+        const customProfiles = customProfileNames.map(name => new CargoProfile(name));
+
+        return [...standardProfiles, ...customProfiles];
     }
 }

--- a/src/cargoTaskProvider.ts
+++ b/src/cargoTaskProvider.ts
@@ -262,10 +262,11 @@ export class CargoTaskProvider implements vscode.TaskProvider {
     private buildCargoArgs(definition: CargoTaskDefinition): string[] {
         const args = [definition.command];
 
-        // Add profile
-        if (definition.profile === 'release' ||
-            (this.workspace.currentProfile.toString() === 'release' && !definition.profile)) {
-            args.push('--release');
+        // Add profile - handle both task-specific and workspace default profiles
+        const profileToUse = definition.profile || this.workspace.currentProfile.toString();
+
+        if (profileToUse !== 'none') {
+            args.push('--profile', profileToUse);
         }
 
         // Find target to get package information

--- a/src/cargoWorkspace.ts
+++ b/src/cargoWorkspace.ts
@@ -53,7 +53,7 @@ export class CargoWorkspace {
     private _workspaceRoot: string;
     private _manifest: CargoManifest | null = null;
     private _targets: CargoTarget[] = [];
-    private _currentProfile: CargoProfile = CargoProfile.dev;
+    private _currentProfile: CargoProfile = CargoProfile.none;
     private _currentTarget: CargoTarget | null = null;
     private _selectedPackage: string | undefined = undefined; // undefined means "No selection"
     private _workspacePackageNames: string[] = []; // Package names from cargo metadata
@@ -653,9 +653,9 @@ export class CargoWorkspace {
     getCargoArgs(command: string, additionalArgs: string[] = []): string[] {
         const args = [command];
 
-        // Add profile
-        if (this._currentProfile === CargoProfile.release) {
-            args.push('--release');
+        // Add profile - use --profile flag for all profiles except "none"
+        if (this._currentProfile !== CargoProfile.none) {
+            args.push('--profile', this._currentProfile);
         }
 
         // Add package argument if a specific package is selected and we're in a workspace

--- a/src/projectStatusTreeProvider.ts
+++ b/src/projectStatusTreeProvider.ts
@@ -217,7 +217,7 @@ export class ProjectStatusTreeProvider implements vscode.TreeDataProvider<Projec
         // Profile node
         const currentProfile = this.workspace.currentProfile || CargoProfile.dev;
         const profileNode = new ProjectStatusNode(
-            currentProfile,
+            currentProfile.toString(),
             vscode.TreeItemCollapsibleState.None,
             'profile',
             {

--- a/src/statusBarProvider.ts
+++ b/src/statusBarProvider.ts
@@ -615,7 +615,7 @@ export class StatusBarProvider implements vscode.Disposable {
 
     // Profile methods
     setProfileName(profile: CargoProfile): void {
-        this._profileButton.text = profile;
+        this._profileButton.text = CargoProfile.getDisplayName(profile);
     }
 
     // Package methods

--- a/test-rust-project/.cargo/config.toml
+++ b/test-rust-project/.cargo/config.toml
@@ -1,0 +1,15 @@
+# Custom cargo configuration
+[profile.debug-optimized]
+inherits = "dev"
+opt-level = 1
+debug = true
+
+[profile.ci]
+inherits = "test"
+opt-level = 0
+overflow-checks = true
+debug-assertions = true
+
+[build]
+# Example build configuration
+target-dir = "target"

--- a/test-rust-project/Cargo.toml
+++ b/test-rust-project/Cargo.toml
@@ -8,3 +8,26 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
+
+# Custom workspace-level profiles
+[profile.fast]
+inherits = "release"
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+panic = "abort"
+
+[profile.staging]
+inherits = "release"
+opt-level = 2
+debug = 1
+overflow-checks = true
+lto = false
+
+[profile.bench-optimized]
+inherits = "release"
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+debug = false


### PR DESCRIPTION
- Convert CargoProfile from enum to class to support dynamic custom profiles
- Add profile discovery from workspace Cargo.toml [profile.*] sections
- Add profile discovery from .cargo/config.toml files (workspace and $CARGO_HOME)
- Support standard profiles: none, dev, release, test, bench (doc excluded from selection)
- Custom profiles use --profile <profile> flag consistently with standard profiles
- Add comprehensive tests for custom profile functionality
- Add integration test using real test project with custom profiles
- Maintain backward compatibility with existing profile selection logic

Custom profiles discovered:
- From workspace Cargo.toml: fast, staging, bench-optimized
- From .cargo/config.toml: debug-optimized, ci