### PR TITLE
Add cargo doc build button with terminal reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
         "icon": "$(cloud-download)"
       },
       {
+        "command": "cargo-tools.buildDocs",
+        "title": "Build Documentation",
+        "category": "Cargo Tools",
+        "icon": "$(book)"
+      },
+      {
         "command": "cargo-tools.selectFeatures",
         "title": "Select Features",
         "category": "Cargo Tools",
@@ -213,6 +219,11 @@
       "view/title": [
         {
           "command": "cargo-tools.refresh",
+          "when": "view == cargoToolsProjectStatus",
+          "group": "navigation"
+        },
+        {
+          "command": "cargo-tools.buildDocs",
           "when": "view == cargoToolsProjectStatus",
           "group": "navigation"
         },

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -31,6 +31,7 @@ suite('Extension Test Suite', () => {
 				assert.ok(commandIds.includes('cargo-tools.selectRunTarget'), 'selectRunTarget command should be defined');
 				assert.ok(commandIds.includes('cargo-tools.selectBenchmarkTarget'), 'selectBenchmarkTarget command should be defined');
 				assert.ok(commandIds.includes('cargo-tools.selectFeatures'), 'selectFeatures command should be defined');
+				assert.ok(commandIds.includes('cargo-tools.buildDocs'), 'buildDocs command should be defined');
 				assert.ok(commandIds.includes('cargo-tools.refresh'), 'refresh command should be defined');
 
 				// Check for context menu commands


### PR DESCRIPTION
- Add buildDocs command to package.json with book icon
- Add buildDocs button to project status view navigation
- Implement buildDocs method in CargoExtensionManager
- Use reusable terminal for cargo doc commands
- Execute 'cargo doc --no-deps --release' command
- Add proper terminal cleanup in dispose method
- Add test for buildDocs command registration
- Respect cargoPath configuration setting