### PR TITLE
Add settings to override cargo run and test commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
-* ✅ debug support
 * settings to override `cargo run`, `cargo test`, etc
+* make project outline view filtrable (name of crate, type of target)
 * use rust-analyzer settings where it makes sense (cargo paths, additional arguments etc)
 * set rust-analyzer settings through convenience commands
-* persist selections via extension constext and appropriate keys analoguous to vscode-cmake-tools
-* cargo make (Makefilew.toml) support
+* persist selections via extension context and appropriate keys analoguous to vscode-cmake-tools
+* cargo make (Makefile.toml) support
     * discover tasks
     * task view by category
     * package selection

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-* settings to override `cargo run`, `cargo test`, etc
 * make project outline view filtrable (name of crate, type of target)
 * use rust-analyzer settings where it makes sense (cargo paths, additional arguments etc)
 * set rust-analyzer settings through convenience commands

--- a/package.json
+++ b/package.json
@@ -495,6 +495,16 @@
           "default": false,
           "description": "Disable default features"
         },
+        "cargoTools.runCommandOverride": {
+          "type": "string",
+          "default": "",
+          "description": "Override command for 'cargo run'. If empty, 'cargo run' will be used. Use this to customize the run command (e.g., 'cargo watch -x run' or custom scripts)."
+        },
+        "cargoTools.testCommandOverride": {
+          "type": "string",
+          "default": "",
+          "description": "Override command for 'cargo test'. If empty, 'cargo test' will be used. Use this to customize the test command (e.g., 'cargo nextest run' or custom scripts)."
+        },
         "cargoTools.groupTargetsByWorkspaceMember": {
           "type": "boolean",
           "default": true,

--- a/src/cargoConfigurationReader.ts
+++ b/src/cargoConfigurationReader.ts
@@ -9,6 +9,8 @@ export interface CargoConfiguration {
     buildArgs: string[];
     runArgs: string[];
     testArgs: string[];
+    runCommandOverride: string;
+    testCommandOverride: string;
     environment: { [key: string]: string };
     features: string[];
     allFeatures: boolean;
@@ -81,6 +83,8 @@ export class CargoConfigurationReader implements vscode.Disposable {
             buildArgs: config.get<string[]>('buildArgs', []),
             runArgs: config.get<string[]>('runArgs', []),
             testArgs: config.get<string[]>('testArgs', []),
+            runCommandOverride: config.get<string>('runCommandOverride', ''),
+            testCommandOverride: config.get<string>('testCommandOverride', ''),
             environment: config.get<{ [key: string]: string }>('environment', {}),
             features: config.get<string[]>('features', []),
             allFeatures: config.get<boolean>('allFeatures', false),
@@ -160,6 +164,14 @@ export class CargoConfigurationReader implements vscode.Disposable {
         return this.configData.testArgs;
     }
 
+    get runCommandOverride(): string {
+        return this.configData.runCommandOverride;
+    }
+
+    get testCommandOverride(): string {
+        return this.configData.testCommandOverride;
+    }
+
     get environment(): { [key: string]: string } {
         return this.configData.environment;
     }
@@ -183,6 +195,8 @@ export class CargoConfigurationReader implements vscode.Disposable {
         buildArgs: new vscode.EventEmitter<string[]>(),
         runArgs: new vscode.EventEmitter<string[]>(),
         testArgs: new vscode.EventEmitter<string[]>(),
+        runCommandOverride: new vscode.EventEmitter<string>(),
+        testCommandOverride: new vscode.EventEmitter<string>(),
         environment: new vscode.EventEmitter<{ [key: string]: string }>(),
         features: new vscode.EventEmitter<string[]>(),
         allFeatures: new vscode.EventEmitter<boolean>(),


### PR DESCRIPTION
Introduce configuration options to customize the commands used for `cargo run` and `cargo test`, enhancing flexibility for users. Update project outline view to be filtrable.