### PR TITLE
Add automatic rust-analyzer target updates and check targets command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-* set rust-analyzer settings through convenience commands
 * persist selections via extension context and appropriate keys analoguous to vscode-cmake-tools
 * cargo make (Makefile.toml) support
     * discover tasks

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-* use rust-analyzer settings where it makes sense (cargo paths, additional arguments etc)
 * set rust-analyzer settings through convenience commands
 * persist selections via extension context and appropriate keys analoguous to vscode-cmake-tools
 * cargo make (Makefile.toml) support

--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
         "icon": "$(cloud-download)"
       },
       {
+        "command": "cargo-tools.setRustAnalyzerCheckTargets",
+        "title": "Set rust-analyzer check targets",
+        "category": "Cargo Tools",
+        "icon": "$(checklist)"
+      },
+      {
         "command": "cargo-tools.buildDocs",
         "title": "Build Documentation",
         "category": "Cargo Tools",

--- a/package.json
+++ b/package.json
@@ -568,6 +568,11 @@
           "default": false,
           "description": "Use rust-analyzer settings for cargo command and environment. When enabled, reads rust-analyzer.cargo.extraArgs, rust-analyzer.cargo.extraEnv, rust-analyzer.runnables.extraArgs, and rust-analyzer.runnables.extraTestBinaryArgs to configure this extension."
         },
+        "cargoTools.updateRustAnalyzerTarget": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically update rust-analyzer.cargo.target setting when Platform Selection changes. When enabled, changing the platform target will also set rust-analyzer's cargo target configuration."
+        },
         "cargoTools.cargoPath": {
           "type": "string",
           "default": "cargo",

--- a/src/cargoConfigurationReader.ts
+++ b/src/cargoConfigurationReader.ts
@@ -7,6 +7,7 @@ export interface CargoConfiguration {
     cargoCommand: string;
     cargoPath: string;
     useRustAnalyzerEnvAndArgs: boolean;
+    updateRustAnalyzerTarget: boolean;
     defaultProfile: string;
     extraEnv: { [key: string]: string };
     buildArgs: string[];
@@ -118,6 +119,7 @@ export class CargoConfigurationReader implements vscode.Disposable {
             cargoCommand: cargoCommand,
             cargoPath: config.get<string>('cargoPath', 'cargo'),
             useRustAnalyzerEnvAndArgs: useRustAnalyzerEnvAndArgs,
+            updateRustAnalyzerTarget: config.get<boolean>('updateRustAnalyzerTarget', false),
             defaultProfile: config.get<string>('defaultProfile', 'dev'),
             extraEnv: extraEnv,
             buildArgs: config.get<string[]>('buildArgs', []),
@@ -200,6 +202,10 @@ export class CargoConfigurationReader implements vscode.Disposable {
         return this.configData.useRustAnalyzerEnvAndArgs;
     }
 
+    get updateRustAnalyzerTarget(): boolean {
+        return this.configData.updateRustAnalyzerTarget;
+    }
+
     get defaultProfile(): string {
         return this.configData.defaultProfile;
     }
@@ -265,6 +271,7 @@ export class CargoConfigurationReader implements vscode.Disposable {
         cargoCommand: new vscode.EventEmitter<string>(),
         cargoPath: new vscode.EventEmitter<string>(),
         useRustAnalyzerEnvAndArgs: new vscode.EventEmitter<boolean>(),
+        updateRustAnalyzerTarget: new vscode.EventEmitter<boolean>(),
         defaultProfile: new vscode.EventEmitter<string>(),
         extraEnv: new vscode.EventEmitter<{ [key: string]: string }>(),
         buildArgs: new vscode.EventEmitter<string[]>(),

--- a/src/cargoWorkspace.ts
+++ b/src/cargoWorkspace.ts
@@ -515,6 +515,21 @@ export class CargoWorkspace {
         if (this._selectedPlatformTarget !== targetTriple) {
             this._selectedPlatformTarget = targetTriple;
             this._onDidChangeSelectedPlatformTarget.fire(this._selectedPlatformTarget);
+
+            // Update rust-analyzer target setting if enabled
+            const config = vscode.workspace.getConfiguration('cargoTools');
+            const updateRustAnalyzer = config.get<boolean>('updateRustAnalyzerTarget', false);
+            
+            if (updateRustAnalyzer) {
+                const rustAnalyzerConfig = vscode.workspace.getConfiguration('rust-analyzer');
+                if (targetTriple) {
+                    // Set rust-analyzer cargo target to the selected platform target
+                    rustAnalyzerConfig.update('cargo.target', targetTriple, vscode.ConfigurationTarget.Workspace);
+                } else {
+                    // Remove rust-analyzer cargo target setting when no selection
+                    rustAnalyzerConfig.update('cargo.target', undefined, vscode.ConfigurationTarget.Workspace);
+                }
+            }
         }
     }
 

--- a/src/cargoWorkspace.ts
+++ b/src/cargoWorkspace.ts
@@ -519,7 +519,7 @@ export class CargoWorkspace {
             // Update rust-analyzer target setting if enabled
             const config = vscode.workspace.getConfiguration('cargoTools');
             const updateRustAnalyzer = config.get<boolean>('updateRustAnalyzerTarget', false);
-            
+
             if (updateRustAnalyzer) {
                 const rustAnalyzerConfig = vscode.workspace.getConfiguration('rust-analyzer');
                 if (targetTriple) {


### PR DESCRIPTION
Introduce a setting to automatically update the rust-analyzer target based on platform selection and add a command to set rust-analyzer check targets. Update related configuration and commands accordingly.