### PR TITLE
Add keybindings and commands for cargo tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-* investigate key kindings/short cuts for common tasks (build, run, test)
 * create extension icon (rust logo with wrench on the lower right corner)
 * extension documentation
 * polish and release

--- a/package.json
+++ b/package.json
@@ -857,6 +857,23 @@
           }
         }
       }
+    ],
+    "keybindings": [
+      {
+        "command": "cargo-tools.projectStatus.build",
+        "key": "f7",
+        "when": "cargoTools:workspaceHasCargo"
+      },
+      {
+        "command": "cargo-tools.projectStatus.run",
+        "key": "ctrl+shift+f5",
+        "when": "cargoTools:workspaceHasCargo"
+      },
+      {
+        "command": "cargo-tools.projectStatus.debug",
+        "key": "shift+f5",
+        "when": "cargoTools:workspaceHasCargo"
+      }
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,36 @@
         "icon": "$(pin)"
       },
       {
+        "command": "cargo-tools.pinnedMakefileTasks.execute1",
+        "title": "Execute 1st Pinned Task",
+        "category": "Cargo Tools",
+        "icon": "$(play)"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute2",
+        "title": "Execute 2nd Pinned Task",
+        "category": "Cargo Tools",
+        "icon": "$(play)"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute3",
+        "title": "Execute 3rd Pinned Task",
+        "category": "Cargo Tools",
+        "icon": "$(play)"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute4",
+        "title": "Execute 4th Pinned Task",
+        "category": "Cargo Tools",
+        "icon": "$(play)"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute5",
+        "title": "Execute 5th Pinned Task",
+        "category": "Cargo Tools",
+        "icon": "$(play)"
+      },
+      {
         "command": "cargo-tools.projectStatus.build",
         "title": "Build",
         "category": "Cargo Tools",
@@ -873,6 +903,31 @@
         "command": "cargo-tools.projectStatus.debug",
         "key": "shift+f5",
         "when": "cargoTools:workspaceHasCargo"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute1",
+        "key": "ctrl+alt+1",
+        "when": "cargoTools:workspaceHasCargo && cargoTools:workspaceHasMakefile"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute2",
+        "key": "ctrl+alt+2",
+        "when": "cargoTools:workspaceHasCargo && cargoTools:workspaceHasMakefile"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute3",
+        "key": "ctrl+alt+3",
+        "when": "cargoTools:workspaceHasCargo && cargoTools:workspaceHasMakefile"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute4",
+        "key": "ctrl+alt+4",
+        "when": "cargoTools:workspaceHasCargo && cargoTools:workspaceHasMakefile"
+      },
+      {
+        "command": "cargo-tools.pinnedMakefileTasks.execute5",
+        "key": "ctrl+alt+5",
+        "when": "cargoTools:workspaceHasCargo && cargoTools:workspaceHasMakefile"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,6 +297,84 @@ async function setup(context: vscode.ExtensionContext): Promise<any> {
 	context.subscriptions.push(executePinnedTaskDisposable);
 	context.subscriptions.push(pinTaskDisposable);
 
+	// Helper function to execute a pinned task by its index position
+	async function executePinnedTaskByIndex(index: number, workspace: any, provider: any): Promise<void> {
+		try {
+			if (!workspace || !workspace.hasMakefileToml) {
+				vscode.window.showErrorMessage('No Makefile.toml found in workspace');
+				return;
+			}
+
+			const pinnedTasks = provider.getPinnedTasks();
+			if (pinnedTasks.length === 0) {
+				vscode.window.showErrorMessage('No pinned makefile tasks found');
+				return;
+			}
+
+			if (index >= pinnedTasks.length) {
+				const position = ['1st', '2nd', '3rd', '4th', '5th'][index] || `${index + 1}th`;
+				vscode.window.showErrorMessage(`No ${position} pinned task found. Only ${pinnedTasks.length} task(s) are pinned.`);
+				return;
+			}
+
+			const taskName = pinnedTasks[index];
+			const position = ['1st', '2nd', '3rd', '4th', '5th'][index] || `${index + 1}th`;
+
+			// Show which task is being run
+			vscode.window.showInformationMessage(`Running ${position} pinned cargo make task: ${taskName}`);
+
+			// Create a terminal and run the cargo make command
+			const terminal = vscode.window.createTerminal({
+				name: `cargo make ${taskName}`,
+				cwd: workspace.workspaceRoot
+			});
+
+			terminal.sendText(`cargo make ${taskName}`);
+			terminal.show();
+
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			vscode.window.showErrorMessage(`Failed to run pinned cargo make task: ${message}`);
+		}
+	}
+
+	// Register pinned makefile task execution commands for specific positions (1st to 5th)
+	const executePinnedTask1Disposable = vscode.commands.registerCommand('cargo-tools.pinnedMakefileTasks.execute1',
+		async () => {
+			await executePinnedTaskByIndex(0, cargoWorkspace, pinnedMakefileTasksProvider);
+		}
+	);
+
+	const executePinnedTask2Disposable = vscode.commands.registerCommand('cargo-tools.pinnedMakefileTasks.execute2',
+		async () => {
+			await executePinnedTaskByIndex(1, cargoWorkspace, pinnedMakefileTasksProvider);
+		}
+	);
+
+	const executePinnedTask3Disposable = vscode.commands.registerCommand('cargo-tools.pinnedMakefileTasks.execute3',
+		async () => {
+			await executePinnedTaskByIndex(2, cargoWorkspace, pinnedMakefileTasksProvider);
+		}
+	);
+
+	const executePinnedTask4Disposable = vscode.commands.registerCommand('cargo-tools.pinnedMakefileTasks.execute4',
+		async () => {
+			await executePinnedTaskByIndex(3, cargoWorkspace, pinnedMakefileTasksProvider);
+		}
+	);
+
+	const executePinnedTask5Disposable = vscode.commands.registerCommand('cargo-tools.pinnedMakefileTasks.execute5',
+		async () => {
+			await executePinnedTaskByIndex(4, cargoWorkspace, pinnedMakefileTasksProvider);
+		}
+	);
+
+	context.subscriptions.push(executePinnedTask1Disposable);
+	context.subscriptions.push(executePinnedTask2Disposable);
+	context.subscriptions.push(executePinnedTask3Disposable);
+	context.subscriptions.push(executePinnedTask4Disposable);
+	context.subscriptions.push(executePinnedTask5Disposable);
+
 	// Subscribe to workspace changes to update providers
 	cargoWorkspace.onDidChangeTargets(() => {
 		projectStatusProvider.refresh();

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -74,6 +74,39 @@ suite('Extension Test Suite', () => {
 			}
 		});
 
+		test('should have key bindings registered for common commands', () => {
+			// Test that the key bindings are properly registered in package.json
+			const extension = vscode.extensions.getExtension('undefined_publisher.cargo-tools');
+			if (extension) {
+				const packageJson = extension.packageJSON;
+				const keybindings = packageJson.contributes?.keybindings || [];
+
+				// Check for the main key bindings
+				const buildKeybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.projectStatus.build' && kb.key === 'f7'
+				);
+				const runKeybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.projectStatus.run' && kb.key === 'ctrl+shift+f5'
+				);
+				const debugKeybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.projectStatus.debug' && kb.key === 'shift+f5'
+				);
+
+				assert.ok(buildKeybinding, 'Build command (F7) key binding should be defined');
+				assert.ok(runKeybinding, 'Run command (Ctrl+Shift+F5) key binding should be defined');
+				assert.ok(debugKeybinding, 'Debug command (Shift+F5) key binding should be defined');
+
+				// Check that they have the correct "when" context
+				assert.strictEqual(buildKeybinding.when, 'cargoTools:workspaceHasCargo', 'Build key binding should have correct when context');
+				assert.strictEqual(runKeybinding.when, 'cargoTools:workspaceHasCargo', 'Run key binding should have correct when context');
+				assert.strictEqual(debugKeybinding.when, 'cargoTools:workspaceHasCargo', 'Debug key binding should have correct when context');
+			} else {
+				// If running without the extension being loaded, just check that 
+				// the test framework is working (integration test framework limitation)
+				assert.ok(true, 'Extension package.json not available in test context');
+			}
+		});
+
 		test('should have cargo tree view provider registered', async () => {
 			// Verify that the cargo tree view is registered and available
 			const treeViews = vscode.window.createTreeView('cargo-tools.targets', {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -741,5 +741,64 @@ suite('Extension Test Suite', () => {
 				assert.ok(addPinnedTaskMenu, 'Add pinned task view title menu should be defined');
 			}
 		});
+
+		test('should have pinned task execution commands (1st to 5th) registered', () => {
+			const extension = vscode.extensions.getExtension('undefined_publisher.cargo-tools');
+			if (extension) {
+				const packageJson = extension.packageJSON;
+				const commands = packageJson.contributes?.commands || [];
+				const commandIds = commands.map((cmd: any) => cmd.command);
+
+				// Check for numbered pinned task execution commands
+				assert.ok(commandIds.includes('cargo-tools.pinnedMakefileTasks.execute1'), 'execute1 command should be defined');
+				assert.ok(commandIds.includes('cargo-tools.pinnedMakefileTasks.execute2'), 'execute2 command should be defined');
+				assert.ok(commandIds.includes('cargo-tools.pinnedMakefileTasks.execute3'), 'execute3 command should be defined');
+				assert.ok(commandIds.includes('cargo-tools.pinnedMakefileTasks.execute4'), 'execute4 command should be defined');
+				assert.ok(commandIds.includes('cargo-tools.pinnedMakefileTasks.execute5'), 'execute5 command should be defined');
+			}
+		});
+
+		test('should have key bindings for pinned task execution commands', () => {
+			const extension = vscode.extensions.getExtension('undefined_publisher.cargo-tools');
+			if (extension) {
+				const packageJson = extension.packageJSON;
+				const keybindings = packageJson.contributes?.keybindings || [];
+
+				// Check for the pinned task execution key bindings
+				const execute1Keybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.pinnedMakefileTasks.execute1' && kb.key === 'ctrl+alt+1'
+				);
+				const execute2Keybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.pinnedMakefileTasks.execute2' && kb.key === 'ctrl+alt+2'
+				);
+				const execute3Keybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.pinnedMakefileTasks.execute3' && kb.key === 'ctrl+alt+3'
+				);
+				const execute4Keybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.pinnedMakefileTasks.execute4' && kb.key === 'ctrl+alt+4'
+				);
+				const execute5Keybinding = keybindings.find((kb: any) =>
+					kb.command === 'cargo-tools.pinnedMakefileTasks.execute5' && kb.key === 'ctrl+alt+5'
+				);
+
+				assert.ok(execute1Keybinding, '1st pinned task (Ctrl+Alt+1) key binding should be defined');
+				assert.ok(execute2Keybinding, '2nd pinned task (Ctrl+Alt+2) key binding should be defined');
+				assert.ok(execute3Keybinding, '3rd pinned task (Ctrl+Alt+3) key binding should be defined');
+				assert.ok(execute4Keybinding, '4th pinned task (Ctrl+Alt+4) key binding should be defined');
+				assert.ok(execute5Keybinding, '5th pinned task (Ctrl+Alt+5) key binding should be defined');
+
+				// Check that they have the correct "when" context
+				const expectedWhen = 'cargoTools:workspaceHasCargo && cargoTools:workspaceHasMakefile';
+				assert.strictEqual(execute1Keybinding.when, expectedWhen, '1st pinned task key binding should have correct when context');
+				assert.strictEqual(execute2Keybinding.when, expectedWhen, '2nd pinned task key binding should have correct when context');
+				assert.strictEqual(execute3Keybinding.when, expectedWhen, '3rd pinned task key binding should have correct when context');
+				assert.strictEqual(execute4Keybinding.when, expectedWhen, '4th pinned task key binding should have correct when context');
+				assert.strictEqual(execute5Keybinding.when, expectedWhen, '5th pinned task key binding should have correct when context');
+			} else {
+				// If running without the extension being loaded, just check that 
+				// the test framework is working (integration test framework limitation)
+				assert.ok(true, 'Extension package.json not available in test context');
+			}
+		});
 	});
 });


### PR DESCRIPTION
Introduce keybindings for building, running, and debugging, along with commands to execute pinned cargo make tasks. Update TODOs to reflect these enhancements.