### PR TITLE
ci: publish extension releases to Open VSX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  # A manual run validates and packages the extension without publishing it.
+  # Manual runs validate/package or check publishing credentials without publishing.
   workflow_dispatch:
     inputs:
       mode:
@@ -15,9 +15,10 @@ on:
         options:
           - build
           - marketplace-identity
+          - openvsx-token
 
 concurrency:
-  group: marketplace-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -139,6 +140,32 @@ jobs:
           echo "Marketplace identity ID: $ID"
           echo "Add this ID to the NickelWenzel Marketplace publisher as a Contributor."
 
+  verify-openvsx-token:
+    name: Verify Open VSX token
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'openvsx-token'
+    runs-on: ubuntu-latest
+    environment: open-vsx
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: npm
+
+      - name: Install publishing tool
+        run: npm ci --ignore-scripts
+
+      - name: Verify Open VSX token
+        run: npm exec -- ovsx verify-pat NickelWenzel --registryUrl https://open-vsx.org
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
   publish-marketplace:
     name: Publish to VS Code Marketplace
     if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -194,10 +221,47 @@ jobs:
       - name: Publish extension
         run: npm exec -- vsce publish --packagePath cargo-tools.vsix --azure-credential
 
+  publish-openvsx:
+    name: Publish to Open VSX
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: build-release
+    runs-on: ubuntu-latest
+    environment: open-vsx
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: npm
+
+      - name: Install publishing tool
+        run: npm ci --ignore-scripts
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cargo-tools-extension-${{ github.sha }}
+
+      - name: Verify release artifact
+        run: sha256sum --check cargo-tools.vsix.sha256
+
+      - name: Publish extension
+        run: npm exec -- ovsx publish cargo-tools.vsix --registryUrl https://open-vsx.org
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
   create-github-release:
     name: Create GitHub release
     if: github.event_name == 'push' && github.ref_type == 'tag'
-    needs: publish-marketplace
+    needs:
+      - publish-marketplace
+      - publish-openvsx
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -230,7 +294,7 @@ jobs:
             echo
             echo "### Installation"
             echo
-            echo "Install from the VS Code Marketplace, or download \`cargo-tools.vsix\` below and run:"
+            echo "Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=NickelWenzel.cargo-tools) or [Open VSX](https://open-vsx.org/extension/NickelWenzel/cargo-tools), or download \`cargo-tools.vsix\` below and run:"
             echo
             echo '```bash'
             echo 'code --install-extension cargo-tools.vsix'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ![Build Status](https://github.com/NickelWenzel/cargo-tools/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-MIT-green)
+[![VS Marketplace](https://img.shields.io/badge/Visual_Studio_Code-0078D4?logo=visual%20studio%20code)](https://marketplace.visualstudio.com/items?itemName=NickelWenzel.cargo-tools)
+[![Open VSX](https://img.shields.io/open-vsx/v/NickelWenzel/cargo-tools?label=Open%20VSX)](https://open-vsx.org/extension/NickelWenzel/cargo-tools)
+[![GitHub Release](https://img.shields.io/github/v/release/NickelWenzel/cargo-tools?label=GitHub%20Release)](https://github.com/NickelWenzel/cargo-tools/releases/latest)
 
 Cargo Tools is a Visual Studio Code extension that provides IDE-like features for Rust/Cargo development. It complements [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) by adding project configuration controls, a workspace target browser, cargo-make task management, and cargo alias shortcuts.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ Cargo Tools is a Visual Studio Code extension that provides IDE-like features fo
 
 ### Installation
 
+Install Cargo Tools from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=NickelWenzel.cargo-tools) or [Open VSX](https://open-vsx.org/extension/NickelWenzel/cargo-tools).
+
 Launch VS Code Quick Open (Ctrl+P), paste the following command, and press enter.
+
 ```bash
 ext install NickelWenzel.cargo-tools
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,15 +1,20 @@
 # Releasing Cargo Tools
 
-Releases are built by GitHub Actions and published to the Visual Studio
-Marketplace with a short-lived Microsoft Entra token. The workflow does not use
-or store an Azure DevOps personal access token.
+Releases are built by GitHub Actions and published to both the Visual Studio
+Marketplace and Open VSX. Marketplace publishing uses a short-lived Microsoft
+Entra token, so the workflow does not use or store an Azure DevOps personal
+access token. Open VSX publishing uses a dedicated access token stored as a
+GitHub environment secret.
 
 ## One-time setup
 
 These steps require access to the Microsoft Entra tenant, the GitHub repository
-settings, and the `NickelWenzel` Visual Studio Marketplace publisher.
+settings, the `NickelWenzel` Visual Studio Marketplace publisher, and the
+`NickelWenzel` Open VSX namespace.
 
-### 1. Create the workload identity
+### Visual Studio Marketplace
+
+#### 1. Create the workload identity
 
 1. In Microsoft Entra ID, create an app registration named something like
    `cargo-tools-marketplace-publisher`.
@@ -28,7 +33,7 @@ The resulting subject must be:
 repo:NickelWenzel/cargo-tools:environment:vscode-marketplace
 ```
 
-### 2. Configure GitHub
+#### 2. Configure GitHub
 
 In **Settings > Environments**, create an environment named
 `vscode-marketplace`.
@@ -45,7 +50,7 @@ recommended so every use of the Marketplace identity needs explicit approval.
 
 No `VSCE_PAT` secret should be configured.
 
-### 3. Authorize the identity in the Marketplace
+#### 3. Authorize the identity in the Marketplace
 
 Open the **Release** workflow in GitHub Actions and run it manually with the
 `marketplace-identity` mode. This performs an OIDC login without publishing and
@@ -61,12 +66,69 @@ Copy the ID from the workflow output. In the Visual Studio Marketplace publisher
 management page, open the `NickelWenzel` publisher and add that identity ID as a
 member with the **Contributor** role.
 
+### Open VSX
+
+#### 1. Link an Eclipse account and accept the Publisher Agreement
+
+1. Create an [Eclipse account](https://accounts.eclipse.org/user/register) and
+   set its GitHub username to the same account used to sign in to Open VSX.
+2. Sign in to [Open VSX](https://open-vsx.org/) with that GitHub account.
+3. In the Open VSX profile settings, choose **Log in with Eclipse** and link the
+   Eclipse account.
+4. Open **Show Publisher Agreement**, read the agreement, and accept it.
+
+The Eclipse Contributor Agreement is separate and is not the agreement required
+for publishing extensions.
+
+#### 2. Create a CI access token
+
+In **Open VSX > Settings > Access Tokens**, generate a token dedicated to this
+repository's GitHub Actions workflow. Copy it immediately because it is shown
+only once.
+
+#### 3. Create and claim the namespace
+
+The extension's `publisher` field is `NickelWenzel`, so its Open VSX namespace
+must be exactly `NickelWenzel` and its extension ID will be
+`NickelWenzel.cargo-tools`.
+
+Create the namespace if it does not exist:
+
+```bash
+read -rsp "Open VSX token: " OVSX_PAT
+export OVSX_PAT
+npx ovsx create-namespace NickelWenzel
+unset OVSX_PAT
+```
+
+Creating a namespace does not make it exclusive. Follow the Open VSX namespace
+ownership process to claim `NickelWenzel`; wait for the claim to be approved if
+approval is required before the first automated release.
+
+#### 4. Configure GitHub
+
+In **Settings > Environments**, create an environment named `open-vsx` and add
+the access token as an environment secret named `OVSX_PAT`.
+
+Restrict the environment to tags matching `v*.*.*` and the protected `master`
+branch. The branch allowance is used only by the manual token check; the publish
+job still accepts tags exclusively. A required reviewer is recommended so each
+use of the publishing token needs explicit approval.
+
+#### 5. Verify the token
+
+Open the **Release** workflow in GitHub Actions and run it manually with the
+`openvsx-token` mode. It runs `ovsx verify-pat` against `https://open-vsx.org`
+to confirm that the token can publish to `NickelWenzel`, without packaging or
+publishing the extension.
+
 ## Validate the workflow without publishing
 
 Run the **Release** workflow manually from the GitHub Actions page with the
 `build` mode. It performs validation, tests, and packaging, then stops before
-authentication and publication. Download the resulting VSIX artifact and test
-it locally:
+authentication and publication. The `marketplace-identity` and `openvsx-token`
+modes independently validate the configured publishing identities without
+publishing. Download the VSIX artifact from a `build` run and test it locally:
 
 ```bash
 code --install-extension cargo-tools.vsix
@@ -101,23 +163,39 @@ code --install-extension cargo-tools.vsix
    git push origin v0.5.1
    ```
 
-6. If configured, approve the `vscode-marketplace` environment deployment.
-7. Verify the new version in both the VS Code Marketplace and GitHub Releases.
+6. If configured, approve the `vscode-marketplace` and `open-vsx` environment
+   deployments.
+7. Verify the new version in the
+   [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=NickelWenzel.cargo-tools),
+   [Open VSX](https://open-vsx.org/extension/NickelWenzel/cargo-tools), and
+   GitHub Releases.
 
 The workflow builds one VSIX, records its SHA-256 digest, publishes that exact
-file to the Marketplace, and attaches the same file and digest to the GitHub
-release. The GitHub release is created only after Marketplace publication
-succeeds.
+file to both registries in parallel, and attaches the same file and digest to
+the GitHub release. The GitHub release is created only after both publications
+succeed.
 
 ## Failure and retry behavior
 
 - A build or validation failure publishes nothing.
-- A Marketplace failure creates no GitHub release. Fix the identity or
-  authorization problem and re-run the failed jobs.
-- If Marketplace publication succeeded but GitHub release creation failed,
-  re-run only the failed GitHub release job. Do not republish the same version.
-- Published Marketplace versions are immutable. Prepare a new patch version to
-  correct an already-published package.
+- The registry publish jobs run in parallel, so one registry can succeed while
+  the other fails. A failure in either registry creates no GitHub release. Fix
+  the credential, authorization, namespace, or registry problem and re-run only
+  the failed publish job; do not re-run a job that already published the version.
+- If both registry publications succeeded but GitHub release creation failed,
+  re-run only the failed GitHub release job.
+- Published registry versions are immutable. Prepare a new patch version to
+  correct an already-published package. An unexpected duplicate-version error
+  must be investigated rather than skipped.
+
+## Rotate the Open VSX token
+
+Generate a replacement token in Open VSX, replace the `OVSX_PAT` secret in the
+`open-vsx` GitHub environment, and run the manual `openvsx-token` check. After
+the check succeeds, delete the old token from Open VSX. Revoke a token
+immediately if it may have been exposed.
 
 Microsoft's current identity-based publishing instructions are documented at
 <https://code.visualstudio.com/api/working-with-extensions/publishing-extension>.
+Open VSX publishing and namespace setup are documented at
+<https://github.com/EclipseFdn/open-vsx.org/wiki/Publishing-Extensions>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@wasm-tool/wasm-pack-plugin": "^1.5.1",
         "copy-webpack-plugin": "^14.0.0",
         "eslint": "^10.8.0",
+        "ovsx": "^1.0.2",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
         "webpack": "^5.99.7",
@@ -246,6 +247,40 @@
         "node": ">=14.17.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -440,6 +475,287 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/crc32": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32/-/crc32-1.10.6.tgz",
+      "integrity": "sha512-+llXfqt+UzgoDzT9of5vPQPGqTAVCohU74I9zIBkNo5TH6s2P31DFJOGsJQKN207f0GHnYv5pV3wh3BCY/un/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/crc32-android-arm-eabi": "1.10.6",
+        "@node-rs/crc32-android-arm64": "1.10.6",
+        "@node-rs/crc32-darwin-arm64": "1.10.6",
+        "@node-rs/crc32-darwin-x64": "1.10.6",
+        "@node-rs/crc32-freebsd-x64": "1.10.6",
+        "@node-rs/crc32-linux-arm-gnueabihf": "1.10.6",
+        "@node-rs/crc32-linux-arm64-gnu": "1.10.6",
+        "@node-rs/crc32-linux-arm64-musl": "1.10.6",
+        "@node-rs/crc32-linux-x64-gnu": "1.10.6",
+        "@node-rs/crc32-linux-x64-musl": "1.10.6",
+        "@node-rs/crc32-wasm32-wasi": "1.10.6",
+        "@node-rs/crc32-win32-arm64-msvc": "1.10.6",
+        "@node-rs/crc32-win32-ia32-msvc": "1.10.6",
+        "@node-rs/crc32-win32-x64-msvc": "1.10.6"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm-eabi": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.10.6.tgz",
+      "integrity": "sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.10.6.tgz",
+      "integrity": "sha512-Vl/JbjCinCw/H9gEpZveWCMjxjcEChDcDBM8S4hKay5yyoRCUHJPuKr4sjVDBeOm+1nwU3oOm6Ca8dyblwp4/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-arm64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.10.6.tgz",
+      "integrity": "sha512-kARYANp5GnmsQiViA5Qu74weYQ3phOHSYQf0G+U5wB3NB5JmBHnZcOc46Ig21tTypWtdv7u63TaltJQE41noyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-x64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.10.6.tgz",
+      "integrity": "sha512-Q99bevJVMfLTISpkpKBlXgtPUItrvTWKFyiqoKH5IvscZmLV++NH4V13Pa17GTBmv9n18OwzgQY4/SRq6PQNVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-freebsd-x64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.10.6.tgz",
+      "integrity": "sha512-66hpawbNjrgnS9EDMErta/lpaqOMrL6a6ee+nlI2viduVOmRZWm9Rg9XdGTK/+c4bQLdtC6jOd+Kp4EyGRYkAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.10.6.tgz",
+      "integrity": "sha512-E8Z0WChH7X6ankbVm8J/Yym19Cq3otx6l4NFPS6JW/cWdjv7iw+Sps2huSug+TBprjbcEA+s4TvEwfDI1KScjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-gnu": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.10.6.tgz",
+      "integrity": "sha512-LmWcfDbqAvypX0bQjQVPmQGazh4dLiVklkgHxpV4P0TcQ1DT86H/SWpMBMs/ncF8DGuCQ05cNyMv1iddUDugoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-musl": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.10.6.tgz",
+      "integrity": "sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-gnu": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.10.6.tgz",
+      "integrity": "sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-musl": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.10.6.tgz",
+      "integrity": "sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-wasm32-wasi": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-wasm32-wasi/-/crc32-wasm32-wasi-1.10.6.tgz",
+      "integrity": "sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-arm64-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.10.6.tgz",
+      "integrity": "sha512-x50AXiSxn5Ccn+dCjLf1T7ZpdBiV1Sp5aC+H2ijhJO4alwznvXgWbopPRVhbp2nj0i+Gb6kkDUEyU+508KAdGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-ia32-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.10.6.tgz",
+      "integrity": "sha512-DpDxQLaErJF9l36aghe1Mx+cOnYLKYo6qVPqPL9ukJ5rAGLtCdU0C+Zoi3gs9ySm8zmbFgazq/LvmsZYU42aBw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-x64-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.10.6.tgz",
+      "integrity": "sha512-5B1vXosIIBw1m2Rcnw62IIfH7W9s9f7H7Ma0rRuhT8HR4Xh8QCgw6NJSI2S2MCngsGktYnAhyUvs81b7efTyQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -749,6 +1065,17 @@
       "license": "MIT",
       "dependencies": {
         "@textlint/ast-node-types": "15.7.1"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/eslint": {
@@ -2093,6 +2420,13 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -2338,6 +2672,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -2349,6 +2701,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -3043,6 +3413,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -3178,6 +3569,23 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
@@ -3227,6 +3635,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -3459,6 +3880,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -3541,6 +3975,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-it-type": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/is-it-type/-/is-it-type-5.1.3.tgz",
+      "integrity": "sha512-AX2uU0HW+TxagTgQXOJY7+2fbFHemC7YFBwN1XqD8qQMKdtfbOC8OC3fUb4s5NU59a3662Dzwto8tWDdZYRXxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalthis": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-number": {
@@ -4289,6 +4736,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4335,6 +4792,39 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ovsx": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-1.0.2.tgz",
+      "integrity": "sha512-N0gWlINGgoOA2Sn0AhrF9L3ap40a/QbsFUpMDKR+CKYyZGJeTFEoNGngplLHjAYtcjrrZv2jX2K7ktPzxWjPNg==",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@vscode/vsce": "^3.7.1",
+        "commander": "^6.2.1",
+        "follow-redirects": "^1.16.0",
+        "is-ci": "^2.0.0",
+        "leven": "^3.1.0",
+        "semver": "^7.6.0",
+        "tmp": "^0.2.3",
+        "yauzl-promise": "^4.0.0"
+      },
+      "bin": {
+        "ovsx": "bin/ovsx"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/ovsx/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/p-limit": {
@@ -5241,6 +5731,16 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-invariant": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/simple-invariant/-/simple-invariant-2.0.1.tgz",
+      "integrity": "sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/slash": {
@@ -6270,6 +6770,21 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yauzl-promise/-/yauzl-promise-4.0.0.tgz",
+      "integrity": "sha512-/HCXpyHXJQQHvFq9noqrjfa/WpQC2XYs3vI7tBiAi4QiIU1knvYhZGaO1QPjwIVMdqflxbmwgMXtYeaRiAE0CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@node-rs/crc32": "^1.7.0",
+        "is-it-type": "^5.1.2",
+        "simple-invariant": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/yazl": {

--- a/package.json
+++ b/package.json
@@ -1060,6 +1060,7 @@
     "@wasm-tool/wasm-pack-plugin": "^1.5.1",
     "copy-webpack-plugin": "^14.0.0",
     "eslint": "^10.8.0",
+    "ovsx": "^1.0.2",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
     "webpack": "^5.99.7",

--- a/vscode_extension/docs/README.md
+++ b/vscode_extension/docs/README.md
@@ -15,7 +15,11 @@ This page walks you through installing Cargo Tools and opening your first Rust p
 
 ## Installation
 
-Install Cargo Tools from the Visual Studio Code Marketplace by searching for *Cargo Tools* in the Extensions view (`Ctrl+Shift+X`), or download a `.vsix` release and install it with **Extensions: Install from VSIX...**.
+Install Cargo Tools from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=NickelWenzel.cargo-tools)
+or [Open VSX](https://open-vsx.org/extension/NickelWenzel/cargo-tools) by
+searching for *Cargo Tools* in your editor's Extensions view (`Ctrl+Shift+X`).
+Alternatively, download a `.vsix` release and install it with **Extensions:
+Install from VSIX...**.
 
 ## Activation
 
@@ -38,4 +42,3 @@ A condensed **Cargo Tools** panel also appears in the Explorer sidebar.
 2. Click the **Cargo Tools** icon in the Activity Bar.
 3. In the **Configuration** view, select a build profile (default: `dev`) and a run target.
 4. Press `F7` to build, `Ctrl+Shift+F5` to run, or `Shift+F5` to debug.
-


### PR DESCRIPTION
## Summary

- publish the same checksummed VSIX to the Visual Studio Marketplace and Open VSX in parallel
- gate GitHub Release creation on both registry publications and add manual Open VSX token verification
- document Open VSX namespace and credential setup, release recovery, installation options, and release badges

## Testing

- cargo compile
- cargo lint
- cargo xt-test
- cargo xt-pkg