### PR TITLE
chore: prepare for 0.6.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to coding agents when working with code in this repository.
+
+## What this project is
+
+A VS Code extension for Rust/Cargo development. It adds project configuration controls, a workspace target browser, cargo-make task management, and xtask alias support on top of rust-analyzer.
+
+## Tooling
+
+**Code navigation and editing**: Use the LSP tool for symbol lookup, go-to-definition, find-references, hover info, and call hierarchies. Do not use Serena MCP tools.
+
+## Development commands
+
+All project verification workflows go through the `xtask` binary via Cargo
+aliases defined in `.cargo/config.toml`. Run the full verification suite only
+when changes affect package or build setup, Rust code, or the development
+environment (including CI, toolchain, and development tooling configuration).
+Documentation-only changes, such as README, release-guide, or badge edits, do
+not require these checks. When verification is required, use these commands:
+
+| Command         | What it does                                      |
+| --------------- | ------------------------------------------------- |
+| `cargo compile` | Build WASM + bundle TypeScript (webpack)          |
+| `cargo lint`    | `cargo clippy` + `cargo fmt --check` + ESLint     |
+| `cargo xt-test` | Rust tests on native and `wasm32-unknown-unknown` |
+| `cargo xt-pkg`  | Produce `cargo-tools.vsix`                        |
+
+Run a single native Rust test: `cargo test <test_name>` inside the relevant package directory.
+
+Run wasm tests only: `cargo test --target wasm32-unknown-unknown`
+
+`wasm-bindgen-test-runner` is configured as the wasm32 test runner in `.cargo/config.toml`.
+
+## Git commits
+
+Always use [Conventional Commits](https://www.conventionalcommits.org/) for
+commit messages, following the `<type>[optional scope]: <description>` format.
+For non-trivial changes, include a concise commit body that motivates the
+change and briefly describes how the resulting behavior was achieved.
+
+## Architecture
+
+This is a three-layer hybrid Rust/TypeScript project:
+
+### Layer 1 — TypeScript (`vscode_extension/src/`)
+A thin VS Code extension entry point. `extension.ts` activates, calls `run(workspaceFolder)` on the WASM module, and returns an `ExitToken`. `runtime.ts` exports VS Code API bindings (file I/O, task execution, logging, state persistence) that the Rust WASM code calls back into.
+
+### Layer 2 — Rust/WASM (`packages/cargo_tools_vscode/`)
+The core extension logic, compiled to `cdylib` targeting `wasm32-unknown-unknown`. Almost all code is guarded by `#[cfg(target_arch = "wasm32")]`. The entry point is `extension::run()` (exported via `wasm_bindgen`), which starts an `iced_viewless` async event loop with a top-level `Extension` state.
+
+All components follow the iced/Elm pattern: `update(state, message) -> Task<Message>`. Components communicate via `Event` types returned alongside tasks (not directly via messages) to avoid coupling.
+
+The `commands/` module is **not** gated on wasm32 — it exists on all targets so that `tests/command_consistency.rs` can compile natively and verify that every command ID in `package.json` has a corresponding implementation. Command IDs are defined in `commands/configuration.rs`, `commands/outline.rs`, `commands/cargo_make.rs`, `commands/pinned.rs`, `commands/xtask.rs`, and `commands/tasks.rs` (shared filter); `commands/cargo.rs` re-exports from the first two so the test can import from a single module.
+
+`extension/vscode_task_utils.rs` contains the shared infrastructure for wiring up VS Code command handlers: `CommandBinding`/`OnFileChanged` type aliases, `send_file_changed`, `take_first`/`take_first_two` argument deserializers, and the generic `register_commands<Cmd, const N>` function. Each `extension/**/command.rs` only needs to define its `Command` enum and a `Command::all()` const array of `(&'static str, fn(Array) -> Option<Command>)` pairs, then call `register_commands(tx, Command::all())`.
+
+### Layer 3 — Rust library (`packages/cargo_tools/`)
+Platform-agnostic core logic; no VS Code or WASM dependencies. The WASM layer's `Extension` state owns two components backed by this library:
+
+- **`Workspace`** (via `cargo::metadata`, `cargo::config`) — watches `Cargo.toml` manifests for changes, parses `cargo metadata` JSON into typed `Metadata`/`Package`/`Target` structs (also reads profile names), and delegates to `Configuration` (build profile, target, feature selection) and `Outline` (project tree view). `cargo::command` builds the typed `Command` enum into CLI arg lists.
+- **`Tasks`** (via `cargo_make` and `xtask`) — parses `Makefile.toml` and delegates to `CargoMake` (task list/filtering) and `Pinned` (pinned task shortcuts); also reads `[alias]` entries from `.cargo/config.toml` via `xtask` and delegates to `Xtask` (alias list/filtering). This covers the [xtask pattern](https://github.com/matklad/cargo-xtask) where a workspace member is invoked as a build tool through a cargo alias. The `Tasks` top-level component also registers two shared VS Code commands (`commands/tasks.rs`) — "Filter by Name" and "Clear All Filters" — that apply to both the cargo-make and alias sub-panels simultaneously. `Pinned` receives both `MakefileTasks` and `XtaskAliases` from the top level so its "Add" picker can present both types in a single quick-pick.
+
+`process` contains the `Process`/`CargoTaskContext` types used to pass executable processes across the WASM boundary.
+
+### `iced_viewless` (`packages/iced_viewless/`)
+A custom iced runtime that runs without any window or UI. Provides `application()` / `async_application()` builder APIs (identical to iced's but headless). Used by `cargo_tools_vscode` to drive the async event loop inside the VS Code extension host (which is already an async JavaScript environment).
+
+## Key invariants
+
+- **wasm32 boundary**: `cargo_tools_vscode` calls back into TypeScript only through `vs_code_api.rs` (which re-exports wasm-bindgen bindings generated from `vscode_extension/src/`). Never call VS Code APIs directly from `cargo_tools`.
+- **Test portability**: Tests in `cargo_tools` use `#[wasm_bindgen_test(unsupported = test)]`, making them runnable on both native (`cargo test`) and wasm32 (`cargo test --target wasm32-unknown-unknown`).
+- **Command consistency**: Adding a new VS Code command requires: (1) adding a string constant to the appropriate `commands/*.rs` file, (2) registering it in `package.json`, (3) adding an entry to `Command::all()` in the matching `extension/**/command.rs`, and (4) adding a variant to that file's `Command` enum and handling it in the component's `update()`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,31 @@ Run wasm tests only: `cargo test --target wasm32-unknown-unknown`
 
 `wasm-bindgen-test-runner` is configured as the wasm32 test runner in `.cargo/config.toml`.
 
+## Preparing a release
+
+Follow `RELEASING.md` for the complete publishing process. When asked to
+prepare version `<version>`:
+
+1. Review all changes since the previous version tag. Add a dated
+   `CHANGELOG.md` section for `<version>` and a comparison link from the
+   previous tag.
+2. Set `<version>` in `package.json`, both root-version entries in
+   `package-lock.json`, `packages/cargo_tools/Cargo.toml`,
+   `packages/cargo_tools_vscode/Cargo.toml`, and the matching first-party
+   entries in `Cargo.lock`.
+3. Update the version-specific npm and Git tag examples in `RELEASING.md`.
+4. Run `npm ci`, followed by the full verification suite listed above.
+5. Confirm the generated `cargo-tools.vsix` contains the expected publisher,
+   extension name, version, and changelog. Also verify that repository-only
+   files such as `AGENTS.md` are absent.
+6. Review `git diff --check` and confirm that only release-preparation files
+   changed.
+
+Preparing a release does not authorize creating or pushing the version tag,
+publishing the extension, or creating a GitHub release. Perform those actions
+only when explicitly requested. Commit preparation changes only when requested,
+using `chore: prepare for <version> release` with a concise commit body.
+
 ## Git commits
 
 Always use [Conventional Commits](https://www.conventionalcommits.org/) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Cargo Tools are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-28
+
+### Added
+
+- Cargo Tools releases are now published to Open VSX alongside the Visual Studio Marketplace.
+
+### Improved
+
+- Feature controls are hidden when a workspace or package has no explicit Cargo features.
+- The **All features** option is shown only when multiple explicit features are available.
+
+### Fixed
+
+- Cargo's implicit `default` feature is no longer displayed as a selectable feature.
+
 ## [0.5.1] - 2026-07-24
 
 ### Fixed
@@ -52,6 +67,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Removed the obsolete repository-level Cargo Make configuration.
 - Improved release and CI task configuration.
 
+[0.6.0]: https://github.com/NickelWenzel/cargo-tools/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/NickelWenzel/cargo-tools/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/NickelWenzel/cargo-tools/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/NickelWenzel/cargo-tools/compare/v0.4.2...v0.4.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_tools"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert2",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_tools_vscode"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "cargo_tools",
  "futures",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -136,31 +136,31 @@ code --install-extension cargo-tools.vsix
 
 ## Publish a release
 
-1. Update `CHANGELOG.md`: replace `Unreleased` with the release date in
-   `YYYY-MM-DD` format.
-2. Set the same version in `package.json` and `package-lock.json`. A convenient
-   command for future versions is:
+1. Add a dated release section to `CHANGELOG.md` in `YYYY-MM-DD` format.
+2. Set the same version in `package.json`, `package-lock.json`, the first-party
+   crate manifests, and `Cargo.lock`. A convenient command for the npm metadata
+   is:
 
    ```bash
-   npm version patch --no-git-tag-version
+   npm version 0.6.0 --no-git-tag-version
    ```
 
 3. Run the local checks:
 
    ```bash
    npm ci
-   npm run lint
-   cargo lint-cargo
+   cargo compile
+   cargo lint
    cargo xt-test
-   npm run package
+   cargo xt-pkg
    ```
 
 4. Commit and merge the release preparation.
 5. Create and push an annotated tag matching the package version:
 
    ```bash
-   git tag -a v0.5.1 -m "Release v0.5.1"
-   git push origin v0.5.1
+   git tag -a v0.6.0 -m "Release v0.6.0"
+   git push origin v0.6.0
    ```
 
 6. If configured, approve the `vscode-marketplace` and `open-vsx` environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cargo-tools",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cargo-tools",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.19.39",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cargo-tools",
   "displayName": "Cargo Tools",
   "description": "Cargo/Rust development tools for Visual Studio Code",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "publisher": "NickelWenzel",
   "license": "MIT",
   "icon": "Ferris-big-tools.png",

--- a/packages/cargo_tools/Cargo.toml
+++ b/packages/cargo_tools/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nicolas Wenzel"]
 edition = "2024"
 name = "cargo_tools"
 publish = false
-version = "0.5.1"
+version = "0.6.0"
 
 [dependencies]
 cargo_metadata = { workspace = true }

--- a/packages/cargo_tools_vscode/Cargo.toml
+++ b/packages/cargo_tools_vscode/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nicolas Wenzel"]
 edition = "2024"
 name = "cargo_tools_vscode"
 publish = false
-version = "0.5.1"
+version = "0.6.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
## Summary

- bump the extension and first-party Rust crates to 0.6.0
- add the dated 0.6.0 changelog entry and update release instructions
- add repository guidance for coding agents and release preparation

## Testing

- npm ci (0 vulnerabilities)
- cargo compile
- cargo lint
- cargo xt-test
- cargo xt-pkg

The packaged extension identifies as NickelWenzel.cargo-tools@0.6.0, includes the 0.6.0 changelog, and excludes AGENTS.md.